### PR TITLE
Add Openstack Flare project

### DIFF
--- a/gerrit/projects.yaml
+++ b/gerrit/projects.yaml
@@ -3364,6 +3364,9 @@
   acl-config: /home/gerrit2/acls/openstack/git-upstream.config
 - project: openstack/flame
   description: Automatic Heat template generation
+- project: openstack/flare
+  description: Flare is a service for running and scheduling burstable task resources
+  use-storyboard: true
 - project: openstack/foxnut
   description: A tool for infrastructure management under OpenStack
 - project: openstack/freezer


### PR DESCRIPTION
Add Openstack Flare project - Openstack Flare is a service for running and scheduling burstable task resources. Typical job is unlimited scientific batch from multiple teams with multiple priorities, which runs on limited compute resources.